### PR TITLE
Fix multiple depends_on

### DIFF
--- a/ecs_composex/ecs/ecs_service.py
+++ b/ecs_composex/ecs/ecs_service.py
@@ -163,7 +163,6 @@ def handle_same_task_services_dependencies(
                         else "HEALTHY",
                     }
                 )
-                service_config.depends_on.pop(count)
 
 
 class Task(object):


### PR DESCRIPTION
It was not possible to have > 1 family dependency due to logic error in `handle_same_task_services_dependencies`